### PR TITLE
Small fixes to polish the template

### DIFF
--- a/myextension/src/myextension.cpp
+++ b/myextension/src/myextension.cpp
@@ -49,13 +49,13 @@ static void LuaInit(lua_State* L)
     assert(top == lua_gettop(L));
 }
 
-dmExtension::Result AppInitializeMyExtension(dmExtension::AppParams* params)
+static dmExtension::Result AppInitializeMyExtension(dmExtension::AppParams* params)
 {
     dmLogInfo("AppInitializeMyExtension\n");
     return dmExtension::RESULT_OK;
 }
 
-dmExtension::Result InitializeMyExtension(dmExtension::Params* params)
+static dmExtension::Result InitializeMyExtension(dmExtension::Params* params)
 {
     // Init Lua
     LuaInit(params->m_L);
@@ -63,25 +63,25 @@ dmExtension::Result InitializeMyExtension(dmExtension::Params* params)
     return dmExtension::RESULT_OK;
 }
 
-dmExtension::Result AppFinalizeMyExtension(dmExtension::AppParams* params)
+static dmExtension::Result AppFinalizeMyExtension(dmExtension::AppParams* params)
 {
     dmLogInfo("AppFinalizeMyExtension\n");
     return dmExtension::RESULT_OK;
 }
 
-dmExtension::Result FinalizeMyExtension(dmExtension::Params* params)
+static dmExtension::Result FinalizeMyExtension(dmExtension::Params* params)
 {
     dmLogInfo("FinalizeMyExtension\n");
     return dmExtension::RESULT_OK;
 }
 
-dmExtension::Result OnUpdateMyExtension(dmExtension::Params* params)
+static dmExtension::Result OnUpdateMyExtension(dmExtension::Params* params)
 {
     dmLogInfo("OnUpdateMyExtension\n");
     return dmExtension::RESULT_OK;
 }
 
-void OnEventMyExtension(dmExtension::Params* params, const dmExtension::Event* event)
+static void OnEventMyExtension(dmExtension::Params* params, const dmExtension::Event* event)
 {
     switch(event->m_Event)
     {

--- a/myextension/src/myextension.cpp
+++ b/myextension/src/myextension.cpp
@@ -51,7 +51,7 @@ static void LuaInit(lua_State* L)
 
 static dmExtension::Result AppInitializeMyExtension(dmExtension::AppParams* params)
 {
-    dmLogInfo("AppInitializeMyExtension\n");
+    dmLogInfo("AppInitializeMyExtension");
     return dmExtension::RESULT_OK;
 }
 
@@ -59,25 +59,25 @@ static dmExtension::Result InitializeMyExtension(dmExtension::Params* params)
 {
     // Init Lua
     LuaInit(params->m_L);
-    dmLogInfo("Registered %s Extension\n", MODULE_NAME);
+    dmLogInfo("Registered %s Extension", MODULE_NAME);
     return dmExtension::RESULT_OK;
 }
 
 static dmExtension::Result AppFinalizeMyExtension(dmExtension::AppParams* params)
 {
-    dmLogInfo("AppFinalizeMyExtension\n");
+    dmLogInfo("AppFinalizeMyExtension");
     return dmExtension::RESULT_OK;
 }
 
 static dmExtension::Result FinalizeMyExtension(dmExtension::Params* params)
 {
-    dmLogInfo("FinalizeMyExtension\n");
+    dmLogInfo("FinalizeMyExtension");
     return dmExtension::RESULT_OK;
 }
 
 static dmExtension::Result OnUpdateMyExtension(dmExtension::Params* params)
 {
-    dmLogInfo("OnUpdateMyExtension\n");
+    dmLogInfo("OnUpdateMyExtension");
     return dmExtension::RESULT_OK;
 }
 
@@ -86,19 +86,19 @@ static void OnEventMyExtension(dmExtension::Params* params, const dmExtension::E
     switch(event->m_Event)
     {
         case dmExtension::EVENT_ID_ACTIVATEAPP:
-            dmLogInfo("OnEventMyExtension - EVENT_ID_ACTIVATEAPP\n");
+            dmLogInfo("OnEventMyExtension - EVENT_ID_ACTIVATEAPP");
             break;
         case dmExtension::EVENT_ID_DEACTIVATEAPP:
-            dmLogInfo("OnEventMyExtension - EVENT_ID_DEACTIVATEAPP\n");
+            dmLogInfo("OnEventMyExtension - EVENT_ID_DEACTIVATEAPP");
             break;
         case dmExtension::EVENT_ID_ICONIFYAPP:
-            dmLogInfo("OnEventMyExtension - EVENT_ID_ICONIFYAPP\n");
+            dmLogInfo("OnEventMyExtension - EVENT_ID_ICONIFYAPP");
             break;
         case dmExtension::EVENT_ID_DEICONIFYAPP:
-            dmLogInfo("OnEventMyExtension - EVENT_ID_DEICONIFYAPP\n");
+            dmLogInfo("OnEventMyExtension - EVENT_ID_DEICONIFYAPP");
             break;
         default:
-            dmLogWarning("OnEventMyExtension - Unknown event id\n");
+            dmLogWarning("OnEventMyExtension - Unknown event id");
             break;
     }
 }


### PR DESCRIPTION
1. Removed unnecessary newlines in the `dmLog*` calls.
2. Declared functions as "static" to avoid conflicts.